### PR TITLE
Downgrade to Poison 2.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Elastic.Mixfile do
   defp deps do
     [
       {:httpotion, "~> 3.0.2"},
-      {:poison, "~> 3.0"},
+      {:poison, "~> 2.2"},
       {:aws_auth, "~> 0.6.1"},
       {:credo, "~> 0.4", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: :dev}


### PR DESCRIPTION
Phoenix 1.2 wants Poison 1.5 or 2.x; Phoenix 1.3 will want Poison 2.2 or 3.0. It smells like the main difference between these versions is removal of some 1.4 compiler warnings, so downgrading for now should be safe.